### PR TITLE
Add custom class to attendees URLs

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/field-url.php
+++ b/public_html/wp-content/plugins/camptix/addons/field-url.php
@@ -75,7 +75,7 @@ class CampTix_Addon_URL_Field extends CampTix_Addon {
 					$label = substr( $label, 4 );
 				}
 
-				printf( '<a class="tix-field tix-attendee-url" href="%s">%s</a>', esc_url( $url ), esc_html( $label ) );
+				printf( '<a class="tix-field tix-attendee-url tix-%s" href="%s">%s</a>', esc_attr( $question->post_name ), esc_url( $url ), esc_html( $label ) );
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Adds a custom class, based on the question name, to URL fields when listing the attendees.
This mimics what happens for other questions where a class `tix-<question-name`> is added, allowing for further styling. Currently URLs only get the same, generic classes making it very difficult to style them according to their nature.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes https://github.com/WordPress/wordcamp.org/issues/1379

### How to test the changes in this Pull Request:

1. Create a ticket, adding 2 or more `URL` questions with different names (e.g. "WP.org profile", "Mastodon profile URL", etc.)
2. Register a new attendee, answering to the `URL` questions above and making sure to answer 'Yes' to 'Do you want to be listed on the public Attendees page? '
3. Visit the Attendees page and check that the URL fields, besides the default `tix-field` and `tix-attendee-url`, now have a custom class based on the related question, e.g. `tix-wp-org-profile`.


