### PR TITLE
Allow a Gravatar `size` attr for the attendees shortcode

### DIFF
--- a/public_html/wp-content/plugins/camptix/addons/shortcodes.php
+++ b/public_html/wp-content/plugins/camptix/addons/shortcodes.php
@@ -213,6 +213,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 				'tickets'        => false,
 				'columns'        => 3,
 				'questions'      => '',
+				'size'           => 96, // Default size for the gravatar
 			),
 			$attr,
 			'camptix_attendees'
@@ -234,6 +235,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 		}
 
 		$attr['posts_per_page'] = absint( $attr['posts_per_page'] );
+		$attr['size'] = absint( $attr['size'] );
 
 		return $attr;
 	}
@@ -316,7 +318,7 @@ class CampTix_Addon_Shortcodes extends CampTix_Addon {
 						$first = get_post_meta( $attendee_id, 'tix_first_name', true );
 						$last  = get_post_meta( $attendee_id, 'tix_last_name', true );
 
-						echo get_avatar( get_post_meta( $attendee_id, 'tix_email', true ) ); // phpcs:ignore
+						echo get_avatar( get_post_meta( $attendee_id, 'tix_email', true ), $attr['size'] ); // phpcs:ignore
 						?>
 
 						<div class="tix-field tix-attendee-name">


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR introduces a new attribute size to the attendees shortcode in the CampTix plugin, which allows the specification of the Gravatar size for attendee images.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes 

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. In a WordCamp website, make sure you have some attendees with gravatars
2. edit the Attendees page and make sure the shortcode is as such:
`[camptix_attendees size="192"]` 
3. add custom CSS to make sure the attendees avatars are 192x192 px in size
4. verify in the frontend of the Attendees page that the vatars are displayed in the correct quality, not as enlarged 96px images

<!-- If you can, add the appropriate [Component] and [Status] labels. -->
